### PR TITLE
Fix json output

### DIFF
--- a/pkg/cli/analyze.go
+++ b/pkg/cli/analyze.go
@@ -38,18 +38,18 @@ func doAnalyze(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	outputFunc := PrintPrettifyOutput
 	out := cmd.Flag("o")
 	if out.Value.String() != "" && !strings.EqualFold(out.Value.String(), "json") {
 		RedirectErrorStringToStdErrAndExit(fmt.Sprintf("unknown value '%s' for flag %s, type --help for a list of all flags\n", out.Value.String(), out.Name))
 	} else if strings.EqualFold(out.Value.String(), "json") {
-		PrintPrettifyJsonOutput(analyzer.AnalyzePath(args[0]))
-		return
+		outputFunc = PrintPrettifyJsonOutput
 	}
 
 	if containerfile.Value.String() != "" {
-		PrintPrettifyOutput(analyzer.AnalyzePath(containerfile.Value.String()))
+		outputFunc(analyzer.AnalyzePath(containerfile.Value.String()))
 	} else if image.Value.String() != "" {
-		PrintPrettifyOutput(analyzer.AnalyzeImage(image.Value.String()))
+		outputFunc(analyzer.AnalyzeImage(image.Value.String()))
 	}
 }
 


### PR DESCRIPTION
Running `doa analyze` with the option `--o json` pacnics:

```
./bin/doa analyze --f Dockerfile --o json
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/redhat-developer/docker-openshift-analyzer/pkg/cli.doAnalyze(0xc0004f8900?, {0xc00070b5c0, 0x0, 0x4?})
	/home/phmartin/Documents/gits/podman-desktop-image-checker-openshift-ext/pkg/cli/analyze.go:45 +0x335
github.com/spf13/cobra.(*Command).execute(0xc0004f8900, {0xc00070b580, 0x4, 0x4})
	/home/phmartin/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004f8600)
	/home/phmartin/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/phmartin/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
	/home/phmartin/Documents/gits/podman-desktop-image-checker-openshift-ext/main.go:36 +0x14f

```
