### PR TITLE
Fix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To build and use the cli, execute
 
 ```
 go build -o doa[.exe]
-doa[.exe] analyze /your/local/project/path[/Dockerfile_name]
+doa[.exe] analyze -f /your/local/project/path[/Dockerfile_name]
 ```
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ By default ports 1-1023 are privileged ports that only the root user can bind. W
 
 An example of a wrong instruction that the tool would detect is
 ```
-EXPOSE 8080
+EXPOSE 80
 ```
 
 with this printed message 

--- a/pkg/cli/analyze.go
+++ b/pkg/cli/analyze.go
@@ -18,28 +18,28 @@ func NewCmdAnalyze() *cobra.Command {
 		Run:     doAnalyze,
 		Example: `  doa analyze -f /your/local/project/path[/Dockerfile_name]`,
 	}
-	analyzeCmd.PersistentFlags().String(
-		"f", "", "Container file to analyze",
+	analyzeCmd.PersistentFlags().StringP(
+		"file", "f", "", "Container file to analyze",
 	)
-	analyzeCmd.PersistentFlags().String(
-		"i", "", "Image name to analyze",
+	analyzeCmd.PersistentFlags().StringP(
+		"image", "i", "", "Image name to analyze",
 	)
-	analyzeCmd.PersistentFlags().String(
-		"o", "", "Specify output format, supported format: json",
+	analyzeCmd.PersistentFlags().StringP(
+		"output", "o", "", "Specify output format, supported format: json",
 	)
 	return analyzeCmd
 }
 
 func doAnalyze(cmd *cobra.Command, args []string) {
-	containerfile := cmd.Flag("f")
-	image := cmd.Flag("i")
+	containerfile := cmd.Flag("file")
+	image := cmd.Flag("image")
 	if containerfile.Value.String() == "" && image.Value.String() == "" {
 		PrintNoArgsWarningMessage(cmd.Name())
 		return
 	}
 
 	outputFunc := PrintPrettifyOutput
-	out := cmd.Flag("o")
+	out := cmd.Flag("output")
 	if out.Value.String() != "" && !strings.EqualFold(out.Value.String(), "json") {
 		RedirectErrorStringToStdErrAndExit(fmt.Sprintf("unknown value '%s' for flag %s, type --help for a list of all flags\n", out.Value.String(), out.Name))
 	} else if strings.EqualFold(out.Value.String(), "json") {


### PR DESCRIPTION
Options with single letter and double dash (`--f`, `--i`, `--o`) are not common. This PR changes to have a long name (file, image, output) with double dash and single letter with single-dash:

```
./bin/doa analyze --help
Analyze the Dockerfile and discover potential issues when deploying it on OpenShift. It accepts the project root path or the Dockerfile path.

Usage:
  doa analyze [flags]

Examples:
  doa analyze -f /your/local/project/path[/Dockerfile_name]

Flags:
  -f, --file string     Container file to analyze
  -h, --help            help for analyze
  -i, --image string    Image name to analyze
  -o, --output string   Specify output format, supported format: json
```


+ Small fix on doc with wrong expose port
