### PR TITLE
fix release script to stay in same repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,8 @@ env:
 
 jobs:
 
-  build:
-    name: Building
+  tag:
+    name: Tagging
     runs-on: ubuntu-22.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
@@ -64,7 +64,6 @@ jobs:
           echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
           git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
           git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
-
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -76,10 +75,13 @@ jobs:
           draft: true
           prerelease: false
 
+  build:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    steps:
       - name: Uninstall existing Podman and dependencies
         run: |
           sudo apt-get -y -q autoremove --purge podman
-
       - name: Install latest podman
         run: |
           sudo apt-get update -y -qq
@@ -93,10 +95,11 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update -qq
           sudo apt-get -qq -y install containernetworking-plugins podman
-
       - run: podman system reset --force
 
       - run: podman info
+
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,8 @@ jobs:
       - run: podman info
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.githubTag }}
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,8 +32,8 @@ env:
 
 jobs:
 
-  tag:
-    name: Tagging
+  build:
+    name: Building
     runs-on: ubuntu-22.04
     outputs:
       githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
@@ -64,6 +64,7 @@ jobs:
           echo "Tagging with ${{ steps.TAG_UTIL.outputs.githubTag }}"
           git tag ${{ steps.TAG_UTIL.outputs.githubTag }}
           git push origin ${{ steps.TAG_UTIL.outputs.githubTag }}
+
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -75,13 +76,10 @@ jobs:
           draft: true
           prerelease: false
 
-  build:
-    needs: [tag]
-    runs-on: ubuntu-latest
-    steps:
       - name: Uninstall existing Podman and dependencies
         run: |
           sudo apt-get -y -q autoremove --purge podman
+
       - name: Install latest podman
         run: |
           sudo apt-get update -y -qq
@@ -95,11 +93,10 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update -qq
           sudo apt-get -qq -y install containernetworking-plugins podman
+
       - run: podman system reset --force
 
       - run: podman info
-
-      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
In the step `tag` the script is modifying the package.json file, but we are building the image from another step, where we checkout the repository agin, and the changes on the package.json file are lost