### PR TITLE
Update README for extension catalog

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,7 +27,7 @@ COPY ./podman-desktop-extension/vite.config.js /opt/app-root/src/
 COPY ./podman-desktop-extension/vitest.config.js /opt/app-root/src/
 COPY ./podman-desktop-extension/LICENSE /opt/app-root/src/
 COPY ./podman-desktop-extension/icon.png /opt/app-root/src/
-COPY ./podman-desktop-extension/README.md /opt/app-root/src/
+COPY ./README.md /opt/app-root/src/
 
 RUN yarn && yarn build
 
@@ -37,7 +37,7 @@ COPY --from=node-builder /opt/app-root/src/dist/ /extension/dist
 COPY ./podman-desktop-extension/package.json /extension/
 COPY ./podman-desktop-extension/LICENSE /extension/
 COPY ./podman-desktop-extension/icon.png /extension/
-COPY ./podman-desktop-extension/README.md /extension/
+COPY ./README.md /extension/
 
 
 FROM --platform=linux/amd64 registry.access.redhat.com/ubi9/go-toolset:1.19.13-4.1697647145 as cli-builder

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ doa[.exe] analyze -f /your/local/project/path[/Containerfile_name]
 Podman Desktop Extension
 ========================
 
-To install the extension on Podman Desktop, you can go to Resources > Extensions, then "Install extension from the OCI image", using the image name: ` ghcr.io/redhat-developer/podman-desktop-image-checker-openshift-ext:<release_name>`
+To install the extension on Podman Desktop, you can go to the "Extensions" tab in the sidebar and search for "Checker".
 
 Contributing
 ============

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ doa[.exe] analyze -f /your/local/project/path[/Containerfile_name]
 Podman Desktop Extension
 ========================
 
-To install the extension on Podman Desktop, you can go to the "Extensions" tab in the sidebar and search for "Checker".
+To install the extension on Podman Desktop, you can click on the "Extensions" icon in the left sidebar and search for "Checker".
 
 Contributing
 ============

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Contributing
 ============
 This is an open source project open to anyone. This project welcomes contributions and suggestions!
 
-For information on getting started, refer to the [CONTRIBUTING instructions](CONTRIBUTING.md).
+For information on getting started, refer to the [CONTRIBUTING instructions](https://github.com/redhat-developer/podman-desktop-image-checker-openshift-ext/blob/main/CONTRIBUTING.md).
 
 
 Feedback & Questions
@@ -114,7 +114,7 @@ If you discover an issue please file a bug and we will fix it as soon as possibl
 
 License
 =======
-Apache 2.0, See [LICENSE](LICENSE) for more information.
+Apache 2.0, See [LICENSE](https://github.com/redhat-developer/podman-desktop-image-checker-openshift-ext/blob/main/LICENSE) for more information.
 
 Acknowledgments
 ===============


### PR DESCRIPTION
Fixes #49 

- Update the README
  - absolute paths to files in repo
  - simplified install procedure
- Use /README.md when publishing extension insteed of podman-desktop-extension/README.md