### PR TITLE
Switch to ESModule

### DIFF
--- a/podman-desktop-extension/package.json
+++ b/podman-desktop-extension/package.json
@@ -6,10 +6,11 @@
   "icon": "icon.png",
   "publisher": "redhat",
   "license": "Apache-2.0",
+  "type": "module",
   "engines": {
     "podman-desktop": "^1.6.3"
   },
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "contributes": {
     "configuration": {}
   },

--- a/podman-desktop-extension/tsconfig.json
+++ b/podman-desktop-extension/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "compilerOptions": {
     "lib": ["ES2017", "webworker"],
+    "module": "ESNext",
+    "target": "ESNext",
     "sourceMap": true,
     "rootDir": "src",
     "outDir": "dist",
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "moduleResolution": "Node",
+    "esModuleInterop": true
   },
   "include": ["src"]
 }

--- a/podman-desktop-extension/vite.config.js
+++ b/podman-desktop-extension/vite.config.js
@@ -51,7 +51,7 @@ const config = {
         ...builtinModules.flatMap(p => [p, `node:${p}`]),
       ],
       output: {
-        entryFileNames: '[name].js',
+        entryFileNames: '[name].cjs',
       },
     },
     emptyOutDir: true,


### PR DESCRIPTION
Switching to ES modules by setting `"type": "module"` in package.json in order to use e2e tests core (@podman-desktop/tests/playwright). Also added settings for modules to tsconfig.json file.