### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/podman-desktop-extension/package.json
+++ b/podman-desktop-extension/package.json
@@ -1,5 +1,7 @@
 {
   "name": "openshift-checker",
+  "repository": "https://github.com/redhat-developer/podman-desktop-image-checker-openshift-ext",
+  "homepage": "https://github.com/redhat-developer/podman-desktop-image-checker-openshift-ext#readme",
   "displayName": "Red Hat OpenShift Checker",
   "description": "Analyze a Containerfile and highlight the directives and commands which could cause an unexpected behavior when running on an OpenShift cluster.",
   "version": "0.0.1",


### PR DESCRIPTION
### What does this PR do?

Add missing `repository` and `homepage` fields in the extension `package.json`.

### Screenshot / video of UI

N/A (metadata-only change)

### What issues does this PR fix or reference?

Closes #101

### How to test this PR?

1. Open `package.json`.
2. Verify both `repository` and `homepage` are present and point to this GitHub repository.
3. Confirm no other files changed.
